### PR TITLE
Feature/retrieve

### DIFF
--- a/ots/ots.go
+++ b/ots/ots.go
@@ -156,6 +156,9 @@ func (c *Client) Generate(passphrase, recipient string, ttl int) (*Secret, error
 	return otsResponse, nil
 }
 
+// Retrieve is used to get the value of a secret which was previously stored. Once you retrieve the secret, it is no longer available.
+// The secretKey parameter is gained from the response when initially creating a secret that is to be shared and the passphrase is what was
+// specified upon creation of the said secret.
 func (c *Client) Retrieve(secretKey, passphrase string) (*Secret, error) {
 
 	endpointKey := fmt.Sprintf("secret/%s", secretKey)


### PR DESCRIPTION
- Adding the `Retrieve` function, enables a user to get a secret value which they previously set or have been given the key to.
- Adding `omitempty` tag to `Secret` struct, so that keys which are not present are not printed with usage.
- Commenting the exported function for usability.