### PR TITLE
Update/requests cleanup

### DIFF
--- a/ots/ots.go
+++ b/ots/ots.go
@@ -54,7 +54,7 @@ func (c *Client) New(user, token string) *Client {
 func (c *Client) Status() error {
 	endpoint := createURI("status")
 
-	req, err := http.NewRequest("GET", endpoint, strings.NewReader(""))
+	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return err
 	}

--- a/ots/ots.go
+++ b/ots/ots.go
@@ -127,37 +127,43 @@ func (c *Client) Create(secret, passphrase, recipient string, ttl int) (*Secret,
 // This request is sent via POST https://onetimesecret.com/api/v1/generate
 func (c *Client) Generate(recipient, passphrase string, ttl int) (*Secret, error) {
 
-	endpoint := createURI("generate")
+	route := "generate"
 
 	v := url.Values{}
 	v.Set("passphrase", passphrase)
 	v.Set("ttl", strconv.Itoa(ttl))
 	v.Set("recipient", recipient)
 
-	req, err := http.NewRequest("POST", endpoint, strings.NewReader(v.Encode()))
-	if err != nil {
-		return nil, err
-	}
-	req.SetBasicAuth(c.Username, c.Token)
-
-	resp, err := c.hc.Do(req)
+	resp, err := c.postRequest(route, strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, err
 	}
 
-	bodyText, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
+	return resp, nil
+	// req, err := http.NewRequest("POST", endpoint, strings.NewReader(v.Encode()))
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// req.SetBasicAuth(c.Username, c.Token)
 
-	var otsResponse *Secret
+	// resp, err := c.hc.Do(req)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	err = json.Unmarshal(bodyText, &otsResponse)
-	if err != nil {
-		return nil, err
-	}
+	// bodyText, err := ioutil.ReadAll(resp.Body)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	return otsResponse, nil
+	// var otsResponse *Secret
+
+	// err = json.Unmarshal(bodyText, &otsResponse)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// return otsResponse, nil
 }
 
 // Retrieve is used to get the value of a secret which was previously stored. Once you retrieve the secret, it is no longer available.

--- a/ots/ots.go
+++ b/ots/ots.go
@@ -272,32 +272,36 @@ func (c *Client) Burn(metadataKey string) (*Secret, error) {
 
 	route := fmt.Sprintf("private/%s/burn", metadataKey)
 
-	endpoint := createURI(route)
-
-	req, err := http.NewRequest("POST", endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.SetBasicAuth(c.Username, c.Token)
-
-	resp, err := c.hc.Do(req)
+	resp, err := c.postRequest(route, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	bodyText, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
+	return resp, nil
+	// req, err := http.NewRequest("POST", endpoint, nil)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// req.SetBasicAuth(c.Username, c.Token)
 
-	var otsResponse *Secret
+	// resp, err := c.hc.Do(req)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	err = json.Unmarshal(bodyText, &otsResponse)
-	if err != nil {
-		return nil, err
-	}
+	// bodyText, err := ioutil.ReadAll(resp.Body)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	return otsResponse, nil
+	// var otsResponse *Secret
+
+	// err = json.Unmarshal(bodyText, &otsResponse)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// return otsResponse, nil
 
 }
 

--- a/ots/ots.go
+++ b/ots/ots.go
@@ -30,11 +30,11 @@ type Secret struct {
 	MetadataKey        string   `json:"metadata_key,omitempty"`
 	SecretKey          string   `json:"secret_key,omitempty"`
 	Value              string   `json:"value,omitempty"`
+	State              string   `json:"state,omitempty"`
+	Recipient          []string `json:"recipient,omitempty`
 	TTL                int      `json:"ttl,omitempty"`
 	MetadataTTL        int      `json:"metadata_ttl,omitempty"`
 	SecretTTL          int      `json:"secret_ttl,omitempty"`
-	Recipient          []string `json:"recipient,omitempty`
-	State              string   `json:"state,omitempty"`
 	Created            int64    `json:"created,omitempty"`
 	Updated            int64    `json:"updated,omitempty"`
 	PassphraseRequired bool     `json:"passphrase_required,omitempty"`

--- a/ots/ots.go
+++ b/ots/ots.go
@@ -31,7 +31,7 @@ type Secret struct {
 	SecretKey          string   `json:"secret_key,omitempty"`
 	Value              string   `json:"value,omitempty"`
 	State              string   `json:"state,omitempty"`
-	Recipient          []string `json:"recipient,omitempty`
+	Recipient          []string `json:"recipient,omitempty"`
 	TTL                int      `json:"ttl,omitempty"`
 	MetadataTTL        int      `json:"metadata_ttl,omitempty"`
 	SecretTTL          int      `json:"secret_ttl,omitempty"`

--- a/ots/ots.go
+++ b/ots/ots.go
@@ -43,7 +43,6 @@ type Secret struct {
 // Secrets is a wrapper type for a slice of Secret
 type Secrets []Secret
 
-
 // Health is a simple struct for verifying the response from the /status endpoint.
 type Health struct {
 	Status string
@@ -118,7 +117,7 @@ func (c *Client) Create(secret, passphrase, recipient string, ttl int) (*Secret,
 	}
 
 	return resp, nil
-	
+
 }
 
 // Generate will return a short, unique secret which is useful for temporary passwords, one-time pads, salts etc.
@@ -155,7 +154,6 @@ func (c *Client) Retrieve(secretKey, passphrase string) (*Secret, error) {
 	v.Set("secret_key", secretKey)
 	v.Set("passphrase", passphrase)
 
-
 	resp, err := c.postRequest(route, strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, err
@@ -166,10 +164,10 @@ func (c *Client) Retrieve(secretKey, passphrase string) (*Secret, error) {
 }
 
 // RetrieveMetadata is used to safely get the associated metadata for particular key. This is intended for the owner of the secret
-// and should be kept private, this lets you view basic information about the secret, such as when or if it has been viewed. 
+// and should be kept private, this lets you view basic information about the secret, such as when or if it has been viewed.
 // This request is sent via POST https://onetimesecret.com/api/v1/private/METADATA_KEY
 func (c *Client) RetrieveMetadata(metadataKey string) (*Secret, error) {
-	
+
 	route := fmt.Sprintf("private/%s", metadataKey)
 
 	resp, err := c.postRequest(route, nil)
@@ -238,7 +236,7 @@ func (c *Client) postRequest(routePath string, body io.Reader) (*Secret, error) 
 		log.Println("POST: Unable to create new request.")
 		return nil, err
 	}
-	
+
 	req.SetBasicAuth(c.Username, c.Token)
 
 	resp, err := c.hc.Do(req)

--- a/ots/ots.go
+++ b/ots/ots.go
@@ -88,7 +88,7 @@ func (c *Client) Status() error {
 // This request is sent via POST https://onetimesecret.com/api/v1/share
 func (c *Client) Create(secret, passphrase, recipient string, ttl int) (*Secret, error) {
 
-	endpoint := createURI("share")
+	route := "share"
 
 	v := url.Values{}
 	v.Set("secret", secret)
@@ -96,30 +96,36 @@ func (c *Client) Create(secret, passphrase, recipient string, ttl int) (*Secret,
 	v.Set("ttl", strconv.Itoa(ttl))
 	v.Set("recipient", recipient)
 
-	req, err := http.NewRequest("POST", endpoint, strings.NewReader(v.Encode()))
-	if err != nil {
-		return nil, err
-	}
-	req.SetBasicAuth(c.Username, c.Token)
-
-	resp, err := c.hc.Do(req)
+	resp, err := c.postRequest(route, strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, err
 	}
 
-	bodyText, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
+	return resp, nil
+	// req, err := http.NewRequest("POST", endpoint, strings.NewReader(v.Encode()))
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// req.SetBasicAuth(c.Username, c.Token)
 
-	var otsResponse *Secret
+	// resp, err := c.hc.Do(req)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	err = json.Unmarshal(bodyText, &otsResponse)
-	if err != nil {
-		return nil, err
-	}
+	// bodyText, err := ioutil.ReadAll(resp.Body)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	return otsResponse, nil
+	// var otsResponse *Secret
+
+	// err = json.Unmarshal(bodyText, &otsResponse)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// return otsResponse, nil
 }
 
 // Generate will return a short, unique secret which is useful for temporary passwords, one-time pads, salts etc.

--- a/ots/ots.go
+++ b/ots/ots.go
@@ -248,6 +248,7 @@ func (c *Client) postRequest(routePath string, body io.Reader) (*Secret, error) 
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Println("POST: Unable to read response into byte array.")
+		return nil, err
 	}
 	var otsResponse *Secret
 

--- a/ots/ots.go
+++ b/ots/ots.go
@@ -118,30 +118,7 @@ func (c *Client) Create(secret, passphrase, recipient string, ttl int) (*Secret,
 	}
 
 	return resp, nil
-	// req, err := http.NewRequest("POST", endpoint, strings.NewReader(v.Encode()))
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// req.SetBasicAuth(c.Username, c.Token)
-
-	// resp, err := c.hc.Do(req)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// bodyText, err := ioutil.ReadAll(resp.Body)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// var otsResponse *Secret
-
-	// err = json.Unmarshal(bodyText, &otsResponse)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// return otsResponse, nil
+	
 }
 
 // Generate will return a short, unique secret which is useful for temporary passwords, one-time pads, salts etc.
@@ -162,30 +139,7 @@ func (c *Client) Generate(recipient, passphrase string, ttl int) (*Secret, error
 	}
 
 	return resp, nil
-	// req, err := http.NewRequest("POST", endpoint, strings.NewReader(v.Encode()))
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// req.SetBasicAuth(c.Username, c.Token)
 
-	// resp, err := c.hc.Do(req)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// bodyText, err := ioutil.ReadAll(resp.Body)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// var otsResponse *Secret
-
-	// err = json.Unmarshal(bodyText, &otsResponse)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// return otsResponse, nil
 }
 
 // Retrieve is used to get the value of a secret which was previously stored. Once you retrieve the secret, it is no longer available.
@@ -208,34 +162,6 @@ func (c *Client) Retrieve(secretKey, passphrase string) (*Secret, error) {
 	}
 
 	return resp, nil
-	// endpoint := createURI(route)
-
-
-	// req, err := http.NewRequest("POST", endpoint, strings.NewReader(v.Encode()))
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// req.SetBasicAuth(c.Username, c.Token)
-
-	// resp, err := c.hc.Do(req)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// bodyText, err := ioutil.ReadAll(resp.Body)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// var otsResponse *Secret
-
-	// err = json.Unmarshal(bodyText, &otsResponse)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-
-	// return otsResponse, nil
 
 }
 
@@ -252,33 +178,7 @@ func (c *Client) RetrieveMetadata(metadataKey string) (*Secret, error) {
 	}
 
 	return resp, nil
-	// endpoint := createURI(route)
 
-	// req, err := http.NewRequest("POST", endpoint, nil)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// req.SetBasicAuth(c.Username, c.Token)
-
-	// resp, err := c.hc.Do(req)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// bodyText, err := ioutil.ReadAll(resp.Body)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// var otsResponse *Secret
-
-	// err = json.Unmarshal(bodyText, &otsResponse)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-
-	// return otsResponse, nil
 }
 
 // Burn will remove a secret, stopping it from being read by the recipient.
@@ -294,30 +194,6 @@ func (c *Client) Burn(metadataKey string) (*Secret, error) {
 	}
 
 	return resp, nil
-	// req, err := http.NewRequest("POST", endpoint, nil)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// req.SetBasicAuth(c.Username, c.Token)
-
-	// resp, err := c.hc.Do(req)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// bodyText, err := ioutil.ReadAll(resp.Body)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// var otsResponse *Secret
-
-	// err = json.Unmarshal(bodyText, &otsResponse)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// return otsResponse, nil
 
 }
 


### PR DESCRIPTION
- Introduced new `postRequest` unexported function to `Client` struct, used for sending generic post requests to various endpoints, this removes a lot of duplicated code.
- Cleanup of code structure using `go fmt`.
- Added `Health` struct for `Status()` func, simple way to check the status string in order to return an error on the API being offline. 