### PR TITLE
Update/cleanup struct

### DIFF
--- a/ots/ots.go
+++ b/ots/ots.go
@@ -22,7 +22,6 @@ const (
 type Client struct {
 	Username string
 	Token    string
-	hc       http.Client
 }
 
 // Secret is a struct which contains the expected fields from the /share API endpoint.
@@ -105,7 +104,7 @@ func (c *Client) Status() error {
 	}
 	req.SetBasicAuth(c.Username, c.Token)
 
-	resp, err := c.hc.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Println("GET: unable to send request.")
 		return err
@@ -246,7 +245,7 @@ func (c *Client) RetrieveRecentMetadata() (*Secrets, error) {
 	}
 	req.SetBasicAuth(c.Username, c.Token)
 
-	resp, err := c.hc.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +277,7 @@ func (c *Client) postRequest(routePath string, body io.Reader) (*Secret, error) 
 
 	req.SetBasicAuth(c.Username, c.Token)
 
-	resp, err := c.hc.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Println("POST: Unable to send request.")
 		return nil, err

--- a/ots/ots.go
+++ b/ots/ots.go
@@ -20,7 +20,11 @@ const (
 
 // Client is used to set the user's 'Username' and 'Token' for interaction with the OneTimeSecret API.
 type Client struct {
+
+	// Your email
 	Username string
+
+	// API token from the OTS website
 	Token    string
 }
 
@@ -76,12 +80,12 @@ type Health struct {
 // in a nicer format.
 func (s *Secret) PrettyPrint() error {
 
-	d, err := json.MarshalIndent(s, "", "\t")
+	prettyJSON, err := json.MarshalIndent(s, "", "\t")
 	if err != nil {
 		return err
 	}
 
-	log.Println(string(d))
+	log.Println(string(prettyJSON))
 	return nil
 }
 


### PR DESCRIPTION
- Adding comments to `Client` struct fields.
- Removing use of `httpClient` inside of `Client` struct, method uses default `httpClient` for simplicity.