### PR TITLE
fix/burn-secret

### DIFF
--- a/ots/ots.go
+++ b/ots/ots.go
@@ -222,8 +222,6 @@ func (c *Client) RetrieveMetadata(metadataKey string) (*Secret, error) {
 
 // Burn will remove a secret, stopping it from being read by the recipient.
 // This request is sent via POST https://onetimesecret.com/api/v1/private/METADATA_KEY/burn
-// NOTE: This endpoint does not seem to work as intended, although is included for potential future changes.
-// Further testing will be done to confirm the root cause, at a later date.
 func (c *Client) Burn(metadataKey string) (*Secret, error) {
 
 	route := fmt.Sprintf("private/%s/burn", metadataKey)
@@ -272,7 +270,7 @@ func (c *Client) RetrieveRecentMetadata() (*Secrets, error) {
 func (c *Client) postRequest(routePath string, body io.Reader) (*Secret, error) {
 
 	endpoint := createURI(routePath)
-
+	log.Println(endpoint)
 	req, err := http.NewRequest("POST", endpoint, body)
 	if err != nil {
 		log.Println("POST: Unable to create new request.")


### PR DESCRIPTION
- Removing comment from `Burn()` func, secret is already burnt, but the API makes it unclear as to whether it has been successful.